### PR TITLE
[Feat] Add CoverageChecker to link in util/Promise.scala

### DIFF
--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -852,7 +852,7 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
   @tailrec
   protected final def link(target: Promise[A]): Unit = {
     val funcName = "link"
-    CoverageChecker.initialize(funcName, 18)
+    CoverageChecker.initialize(funcName, 19)
     if (this eq target) {
       CoverageChecker.reached(funcName, 0)
       return
@@ -910,16 +910,18 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
         if (!target.updateIfEmpty(value) && value != Await.result(target)) {
           CoverageChecker.reached(funcName, 14)
           throw new IllegalArgumentException("Cannot link two Done Promises with differing values")
+        } else {
+          CoverageChecker.reached(funcName, 15)
         }
 
       case p: Promise[A] /* Linked */ =>
-        CoverageChecker.reached(funcName, 15)
+        CoverageChecker.reached(funcName, 16)
         if (cas(p, target)) {
-          CoverageChecker.reached(funcName, 16)
+          CoverageChecker.reached(funcName, 17)
           p.link(target)
         }
         else {
-          CoverageChecker.reached(funcName, 17)
+          CoverageChecker.reached(funcName, 18)
           link(target)
         }
     }

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -1,6 +1,7 @@
 package com.twitter.util
 
 import com.twitter.concurrent.Scheduler
+import com.twitter.util.CoverageChecker
 import scala.annotation.tailrec
 import scala.runtime.NonLocalReturnControl
 import scala.util.control.NonFatal
@@ -850,55 +851,75 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
 
   @tailrec
   protected final def link(target: Promise[A]): Unit = {
+    val funcName = "link"
+    CoverageChecker.initialize(funcName, 18)
     if (this eq target) {
+      CoverageChecker.reached(funcName, 0)
       return
     }
 
     state match {
       case waitq: WaitQueue[A] =>
+        CoverageChecker.reached(funcName, 1)
         if (!cas(waitq, target)) {
+          CoverageChecker.reached(funcName, 2)
           link(target)
         }
         else {
+          CoverageChecker.reached(funcName, 3)
           target.continueAll(waitq)
         }
       case s: Interruptible[A] =>
+        CoverageChecker.reached(funcName, 4)
         if (!cas(s, target)) {
+          CoverageChecker.reached(funcName, 5)
           link(target)
         }
         else {
+          CoverageChecker.reached(funcName, 6)
           target.continueAll(s.waitq)
           target.setInterruptHandler(s.handler)
         }
 
       case s: Transforming[A] =>
+        CoverageChecker.reached(funcName, 7)
         if (!cas(s, target)) {
+          CoverageChecker.reached(funcName, 8)
           link(target)
         }
         else {
+          CoverageChecker.reached(funcName, 9)
           target.continueAll(s.waitq)
           target.forwardInterruptsTo(s.other)
         }
 
       case s: Interrupted[A] =>
+        CoverageChecker.reached(funcName, 10)
         if (!cas(s, target)) {
+          CoverageChecker.reached(funcName, 11)
           link(target)
         }
         else {
+          CoverageChecker.reached(funcName, 12)
           target.continueAll(s.waitq)
           target.raise(s.signal)
         }
 
       case value: Try[A] /* Done */ =>
+        CoverageChecker.reached(funcName, 13)
         if (!target.updateIfEmpty(value) && value != Await.result(target)) {
+          CoverageChecker.reached(funcName, 14)
           throw new IllegalArgumentException("Cannot link two Done Promises with differing values")
         }
 
       case p: Promise[A] /* Linked */ =>
+        CoverageChecker.reached(funcName, 15)
         if (cas(p, target)) {
+          CoverageChecker.reached(funcName, 16)
           p.link(target)
         }
         else {
+          CoverageChecker.reached(funcName, 17)
           link(target)
         }
     }

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -850,29 +850,40 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
 
   @tailrec
   protected final def link(target: Promise[A]): Unit = {
-    if (this eq target) return
+    if (this eq target) {
+      return
+    }
 
     state match {
       case waitq: WaitQueue[A] =>
-        if (!cas(waitq, target)) link(target)
-        else target.continueAll(waitq)
-
+        if (!cas(waitq, target)) {
+          link(target)
+        }
+        else {
+          target.continueAll(waitq)
+        }
       case s: Interruptible[A] =>
-        if (!cas(s, target)) link(target)
+        if (!cas(s, target)) {
+          link(target)
+        }
         else {
           target.continueAll(s.waitq)
           target.setInterruptHandler(s.handler)
         }
 
       case s: Transforming[A] =>
-        if (!cas(s, target)) link(target)
+        if (!cas(s, target)) {
+          link(target)
+        }
         else {
           target.continueAll(s.waitq)
           target.forwardInterruptsTo(s.other)
         }
 
       case s: Interrupted[A] =>
-        if (!cas(s, target)) link(target)
+        if (!cas(s, target)) {
+          link(target)
+        }
         else {
           target.continueAll(s.waitq)
           target.raise(s.signal)
@@ -884,8 +895,12 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
         }
 
       case p: Promise[A] /* Linked */ =>
-        if (cas(p, target)) p.link(target)
-        else link(target)
+        if (cas(p, target)) {
+          p.link(target)
+        }
+        else {
+          link(target)
+        }
     }
   }
 

--- a/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
@@ -340,4 +340,8 @@ class PromiseTest extends FunSuite {
     assert("main thread" == Await.result(p2, 3.seconds))
     assert("main thread" == Await.result(p, 3.seconds))
   }
+
+  test("CoverageChecker") {
+    println("[Coverage - link] - " + CoverageChecker.map.getOrElse("link", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+  }
 }


### PR DESCRIPTION
This commit introduces functionality for checking coverage of the function `link` in Promise.scala. It utilizes the CoverageChecker class for this purpose. This resovles #4.

[Issue: #4]