### PR TITLE
[Feat] Add CoverageChecker to continue in util/Promise.scala

### DIFF
--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -842,33 +842,37 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
 
   @tailrec
   protected final def continue(k: K[A]): Unit = {
-    CoverageChecker.initialize("detach", 6)
+    CoverageChecker.initialize("continue", 10)
     state match {
       case waitq: WaitQueue[A] =>
+        CoverageChecker.reached("continue", 0)
         if (!cas(waitq, WaitQueue(k, waitq))) {
-          CoverageChecker.reached("continue", 0)
-          continue(k)
-        }
-      case s: Interruptible[A] =>
-        if (!cas(s, new Interruptible(WaitQueue(k, s.waitq), s.handler, s.saved))) {
           CoverageChecker.reached("continue", 1)
           continue(k)
         }
-      case s: Transforming[A] =>
-        if (!cas(s, new Transforming(WaitQueue(k, s.waitq), s.other))) {
-          CoverageChecker.reached("continue", 2)
-          continue(k)
-        }
-      case s: Interrupted[A] =>
-        if (!cas(s, new Interrupted(WaitQueue(k, s.waitq), s.signal))) {
+      case s: Interruptible[A] =>
+        CoverageChecker.reached("continue", 2)
+        if (!cas(s, new Interruptible(WaitQueue(k, s.waitq), s.handler, s.saved))) {
           CoverageChecker.reached("continue", 3)
           continue(k)
         }
-      case v: Try[A] /* Done */ => 
+      case s: Transforming[A] =>
         CoverageChecker.reached("continue", 4)
+        if (!cas(s, new Transforming(WaitQueue(k, s.waitq), s.other))) {
+          CoverageChecker.reached("continue", 5)
+          continue(k)
+        }
+      case s: Interrupted[A] =>
+        CoverageChecker.reached("continue", 6)
+        if (!cas(s, new Interrupted(WaitQueue(k, s.waitq), s.signal))) {
+          CoverageChecker.reached("continue", 7)
+          continue(k)
+        }
+      case v: Try[A] /* Done */ => 
+        CoverageChecker.reached("continue", 8)
         k.runInScheduler(v)
       case p: Promise[A] /* Linked */ => 
-        CoverageChecker.reached("continue", 5)
+        CoverageChecker.reached("continue", 9)
         p.continue(k)
     }
 

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -842,7 +842,7 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
 
   @tailrec
   protected final def continue(k: K[A]): Unit = {
-    CoverageChecker.initialize("continue", 14)
+    CoverageChecker.initialize("continue", 15)
     state match {
       case waitq: WaitQueue[A] =>
         CoverageChecker.reached("continue", 0)
@@ -882,6 +882,7 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
       case p: Promise[A] /* Linked */ => 
         CoverageChecker.reached("continue", 13)
         p.continue(k)
+      case _ => CoverageChecker.reached("continue", 14)
     }
 
   }

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -842,37 +842,45 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
 
   @tailrec
   protected final def continue(k: K[A]): Unit = {
-    CoverageChecker.initialize("continue", 10)
+    CoverageChecker.initialize("continue", 14)
     state match {
       case waitq: WaitQueue[A] =>
         CoverageChecker.reached("continue", 0)
         if (!cas(waitq, WaitQueue(k, waitq))) {
           CoverageChecker.reached("continue", 1)
           continue(k)
+        } else {
+          CoverageChecker.reached("continue", 2)
         }
       case s: Interruptible[A] =>
-        CoverageChecker.reached("continue", 2)
+        CoverageChecker.reached("continue", 3)
         if (!cas(s, new Interruptible(WaitQueue(k, s.waitq), s.handler, s.saved))) {
-          CoverageChecker.reached("continue", 3)
+          CoverageChecker.reached("continue", 4)
           continue(k)
+        } else {
+          CoverageChecker.reached("continue", 5)
         }
       case s: Transforming[A] =>
-        CoverageChecker.reached("continue", 4)
-        if (!cas(s, new Transforming(WaitQueue(k, s.waitq), s.other))) {
-          CoverageChecker.reached("continue", 5)
-          continue(k)
-        }
-      case s: Interrupted[A] =>
         CoverageChecker.reached("continue", 6)
-        if (!cas(s, new Interrupted(WaitQueue(k, s.waitq), s.signal))) {
+        if (!cas(s, new Transforming(WaitQueue(k, s.waitq), s.other))) {
           CoverageChecker.reached("continue", 7)
           continue(k)
+        } else {
+          CoverageChecker.reached("continue", 8)
+        }
+      case s: Interrupted[A] =>
+        CoverageChecker.reached("continue", 9)
+        if (!cas(s, new Interrupted(WaitQueue(k, s.waitq), s.signal))) {
+          CoverageChecker.reached("continue", 10)
+          continue(k)
+        } else {
+          CoverageChecker.reached("continue", 11)
         }
       case v: Try[A] /* Done */ => 
-        CoverageChecker.reached("continue", 8)
+        CoverageChecker.reached("continue", 12)
         k.runInScheduler(v)
       case p: Promise[A] /* Linked */ => 
-        CoverageChecker.reached("continue", 9)
+        CoverageChecker.reached("continue", 13)
         p.continue(k)
     }
 

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -841,21 +841,37 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
   }
 
   @tailrec
-  protected final def continue(k: K[A]): Unit = state match {
-    case waitq: WaitQueue[A] =>
-      if (!cas(waitq, WaitQueue(k, waitq)))
-        continue(k)
-    case s: Interruptible[A] =>
-      if (!cas(s, new Interruptible(WaitQueue(k, s.waitq), s.handler, s.saved)))
-        continue(k)
-    case s: Transforming[A] =>
-      if (!cas(s, new Transforming(WaitQueue(k, s.waitq), s.other)))
-        continue(k)
-    case s: Interrupted[A] =>
-      if (!cas(s, new Interrupted(WaitQueue(k, s.waitq), s.signal)))
-        continue(k)
-    case v: Try[A] /* Done */ => k.runInScheduler(v)
-    case p: Promise[A] /* Linked */ => p.continue(k)
+  protected final def continue(k: K[A]): Unit = {
+    CoverageChecker.initialize("detach", 6)
+    state match {
+      case waitq: WaitQueue[A] =>
+        if (!cas(waitq, WaitQueue(k, waitq))) {
+          CoverageChecker.reached("continue", 0)
+          continue(k)
+        }
+      case s: Interruptible[A] =>
+        if (!cas(s, new Interruptible(WaitQueue(k, s.waitq), s.handler, s.saved))) {
+          CoverageChecker.reached("continue", 1)
+          continue(k)
+        }
+      case s: Transforming[A] =>
+        if (!cas(s, new Transforming(WaitQueue(k, s.waitq), s.other))) {
+          CoverageChecker.reached("continue", 2)
+          continue(k)
+        }
+      case s: Interrupted[A] =>
+        if (!cas(s, new Interrupted(WaitQueue(k, s.waitq), s.signal))) {
+          CoverageChecker.reached("continue", 3)
+          continue(k)
+        }
+      case v: Try[A] /* Done */ => 
+        CoverageChecker.reached("continue", 4)
+        k.runInScheduler(v)
+      case p: Promise[A] /* Linked */ => 
+        CoverageChecker.reached("continue", 5)
+        p.continue(k)
+    }
+
   }
 
   /**

--- a/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
@@ -343,8 +343,8 @@ class PromiseTest extends FunSuite {
   }
 
   test("CoverageChecker") {
-    println("[Coverage] - " + CoverageChecker.map.getOrElse("detach", sys.error(s"unexpected key")).mkString("[",", ", "]"))
-    println("[Coverage] - " + CoverageChecker.map.getOrElse("continue", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+    println("[Coverage] - detach" + CoverageChecker.map.getOrElse("detach", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+    println("[Coverage] - continue" + CoverageChecker.map.getOrElse("continue", sys.error(s"unexpected key")).mkString("[",", ", "]"))
   }
 
 }

--- a/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
@@ -345,4 +345,7 @@ class PromiseTest extends FunSuite {
   test("CoverageChecker") {
     println("[Coverage] - " + CoverageChecker.map.getOrElse("detach", sys.error(s"unexpected key")).mkString("[",", ", "]"))
   }
+  test("CoverageChecker") {
+    println("[Coverage] - " + CoverageChecker.map.getOrElse("continue", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+  }
 }

--- a/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
@@ -344,8 +344,7 @@ class PromiseTest extends FunSuite {
 
   test("CoverageChecker") {
     println("[Coverage] - " + CoverageChecker.map.getOrElse("detach", sys.error(s"unexpected key")).mkString("[",", ", "]"))
-  }
-  test("CoverageChecker") {
     println("[Coverage] - " + CoverageChecker.map.getOrElse("continue", sys.error(s"unexpected key")).mkString("[",", ", "]"))
   }
+
 }


### PR DESCRIPTION
This commit introduces functionality for checking coverage of the function continue in Promise.scala. It utilizes the CoverageChecker class for this purpose. This resovles #10.

[Issue: #10]