### PR TITLE
[feat] Add CoverageChecker to raise in util/Promise.scala

### DIFF
--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -607,7 +607,9 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
             try {
               s.handler.applyOrElse(intr, Promise.AlwaysUnit)
             } catch {
-              case _: Throwable => CoverageChecker.reached(funcName, 8) 
+              case e: Throwable => 
+                CoverageChecker.reached(funcName, 8) 
+                throw e
             } finally {
               Local.restore(current)
             }

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -576,7 +576,7 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
 
   @tailrec final def raise(intr: Throwable): Unit = {
     val funcName = "raise"
-    CoverageChecker.initialize(funcName, 16)
+    CoverageChecker.initialize(funcName, 15)
     state match {
       case waitq: WaitQueue[A] =>
         if (!cas(waitq, new Interrupted(waitq, intr))) {
@@ -638,9 +638,7 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
   
       case p: Promise[A] /* Linked */ => 
         CoverageChecker.reached(funcName, 14)
-        p.raise(intr)     
-
-      case _ => CoverageChecker.reached(funcName, 15)
+        p.raise(intr)      
     }
   }
 

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -580,28 +580,34 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
     state match {
       case waitq: WaitQueue[A] =>
         if (!cas(waitq, new Interrupted(waitq, intr))) {
+          CoverageChecker.reached(funcName, 0)
           raise(intr)
         } else {
-        
+          CoverageChecker.reached(funcName, 0)
         }
   
       case s: Interruptible[A] =>
         if (!cas(s, new Interrupted(s.waitq, intr))) {
+          CoverageChecker.reached(funcName, 0)
           raise(intr)
         } else {
+          CoverageChecker.reached(funcName, 0)
           if (!UseLocalInInterruptible) {
+            CoverageChecker.reached(funcName, 0)
             s.handler.applyOrElse(intr, Promise.AlwaysUnit)
           } else {
+            CoverageChecker.reached(funcName, 0)
             val current = Local.save()
             if (current ne s.saved) {
+              CoverageChecker.reached(funcName, 0)
               Local.restore(s.saved)
             } else {
-            
+              CoverageChecker.reached(funcName, 0)
             }
             try {
               s.handler.applyOrElse(intr, Promise.AlwaysUnit)
             } catch {
-              case _: Throwable => println("HERE") 
+              case _: Throwable => CoverageChecker.reached(funcName, 0) 
             } finally {
               Local.restore(current)
             }
@@ -610,21 +616,26 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
   
       case s: Transforming[A] =>
         if (!cas(s, new Interrupted(s.waitq, intr))) {
+          CoverageChecker.reached(funcName, 0)
           raise(intr)
         } else {
+          CoverageChecker.reached(funcName, 0)
           s.other.raise(intr)
         }
   
       case s: Interrupted[A] =>
         if (!cas(s, new Interrupted(s.waitq, intr))) {
+          CoverageChecker.reached(funcName, 0)
           raise(intr)
         } else {
-          
+          CoverageChecker.reached(funcName, 0)
         }
       case _: Try[A] /* Done */ => 
+        CoverageChecker.reached(funcName, 0)
         () // nothing to do, as its already satisfied.
   
       case p: Promise[A] /* Linked */ => 
+        CoverageChecker.reached(funcName, 0)
         p.raise(intr)      
     }
   }

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -575,6 +575,8 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
   }
 
   @tailrec final def raise(intr: Throwable): Unit = {
+    val funcName = "raise"
+    CoverageChecker.initialize(funcName, 10)
     state match {
       case waitq: WaitQueue[A] =>
         if (!cas(waitq, new Interrupted(waitq, intr))) {
@@ -589,8 +591,7 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
         } else {
           if (!UseLocalInInterruptible) {
             s.handler.applyOrElse(intr, Promise.AlwaysUnit)
-          }
-          else {
+          } else {
             val current = Local.save()
             if (current ne s.saved) {
               Local.restore(s.saved)
@@ -610,14 +611,15 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
       case s: Transforming[A] =>
         if (!cas(s, new Interrupted(s.waitq, intr))) {
           raise(intr)
-        }
-        else {
+        } else {
           s.other.raise(intr)
         }
   
       case s: Interrupted[A] =>
         if (!cas(s, new Interrupted(s.waitq, intr))) {
           raise(intr)
+        } else {
+          
         }
       case _: Try[A] /* Done */ => 
         () // nothing to do, as its already satisfied.

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -584,8 +584,7 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
     case s: Interruptible[A] =>
       if (!cas(s, new Interrupted(s.waitq, intr))) {
         raise(intr)
-      }
-      else {
+      } else {
         if (!UseLocalInInterruptible) {
           s.handler.applyOrElse(intr, Promise.AlwaysUnit)
         }
@@ -593,9 +592,16 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
           val current = Local.save()
           if (current ne s.saved) {
             Local.restore(s.saved)
+          } else {
+
           }
-          try s.handler.applyOrElse(intr, Promise.AlwaysUnit)
-          finally Local.restore(current)
+          try {
+            s.handler.applyOrElse(intr, Promise.AlwaysUnit)
+          } catch {
+            case _: Throwable => println("HERE") 
+          } finally {
+            Local.restore(current)
+          }
         }
       }
 
@@ -611,9 +617,11 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
       if (!cas(s, new Interrupted(s.waitq, intr))) {
         raise(intr)
       }
-    case _: Try[A] /* Done */ => () // nothing to do, as its already satisfied.
+    case _: Try[A] /* Done */ => 
+      () // nothing to do, as its already satisfied.
 
-    case p: Promise[A] /* Linked */ => p.raise(intr)
+    case p: Promise[A] /* Linked */ => 
+      p.raise(intr)
   }
 
   @tailrec protected[Promise] final def detach(k: K[A]): Boolean = {

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -576,7 +576,7 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
 
   @tailrec final def raise(intr: Throwable): Unit = {
     val funcName = "raise"
-    CoverageChecker.initialize(funcName, 15)
+    CoverageChecker.initialize(funcName, 16)
     state match {
       case waitq: WaitQueue[A] =>
         if (!cas(waitq, new Interrupted(waitq, intr))) {
@@ -638,7 +638,9 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
   
       case p: Promise[A] /* Linked */ => 
         CoverageChecker.reached(funcName, 14)
-        p.raise(intr)      
+        p.raise(intr)     
+
+      case _ => CoverageChecker.reached(funcName, 15)
     }
   }
 

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -576,38 +576,38 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
 
   @tailrec final def raise(intr: Throwable): Unit = {
     val funcName = "raise"
-    CoverageChecker.initialize(funcName, 10)
+    CoverageChecker.initialize(funcName, 15)
     state match {
       case waitq: WaitQueue[A] =>
         if (!cas(waitq, new Interrupted(waitq, intr))) {
           CoverageChecker.reached(funcName, 0)
           raise(intr)
         } else {
-          CoverageChecker.reached(funcName, 0)
+          CoverageChecker.reached(funcName, 1)
         }
   
       case s: Interruptible[A] =>
         if (!cas(s, new Interrupted(s.waitq, intr))) {
-          CoverageChecker.reached(funcName, 0)
+          CoverageChecker.reached(funcName, 2)
           raise(intr)
         } else {
-          CoverageChecker.reached(funcName, 0)
+          CoverageChecker.reached(funcName, 3)
           if (!UseLocalInInterruptible) {
-            CoverageChecker.reached(funcName, 0)
+            CoverageChecker.reached(funcName, 4)
             s.handler.applyOrElse(intr, Promise.AlwaysUnit)
           } else {
-            CoverageChecker.reached(funcName, 0)
+            CoverageChecker.reached(funcName, 5)
             val current = Local.save()
             if (current ne s.saved) {
-              CoverageChecker.reached(funcName, 0)
+              CoverageChecker.reached(funcName, 6)
               Local.restore(s.saved)
             } else {
-              CoverageChecker.reached(funcName, 0)
+              CoverageChecker.reached(funcName, 7)
             }
             try {
               s.handler.applyOrElse(intr, Promise.AlwaysUnit)
             } catch {
-              case _: Throwable => CoverageChecker.reached(funcName, 0) 
+              case _: Throwable => CoverageChecker.reached(funcName, 8) 
             } finally {
               Local.restore(current)
             }
@@ -616,26 +616,26 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
   
       case s: Transforming[A] =>
         if (!cas(s, new Interrupted(s.waitq, intr))) {
-          CoverageChecker.reached(funcName, 0)
+          CoverageChecker.reached(funcName, 9)
           raise(intr)
         } else {
-          CoverageChecker.reached(funcName, 0)
+          CoverageChecker.reached(funcName, 10)
           s.other.raise(intr)
         }
   
       case s: Interrupted[A] =>
         if (!cas(s, new Interrupted(s.waitq, intr))) {
-          CoverageChecker.reached(funcName, 0)
+          CoverageChecker.reached(funcName, 11)
           raise(intr)
         } else {
-          CoverageChecker.reached(funcName, 0)
+          CoverageChecker.reached(funcName, 12)
         }
       case _: Try[A] /* Done */ => 
-        CoverageChecker.reached(funcName, 0)
+        CoverageChecker.reached(funcName, 13)
         () // nothing to do, as its already satisfied.
   
       case p: Promise[A] /* Linked */ => 
-        CoverageChecker.reached(funcName, 0)
+        CoverageChecker.reached(funcName, 14)
         p.raise(intr)      
     }
   }

--- a/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
@@ -343,6 +343,7 @@ class PromiseTest extends FunSuite {
   }
 
   test("CoverageChecker") {
-    println("[Coverage] - " + CoverageChecker.map.getOrElse("detach", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+    println("[Coverage - detach] - " + CoverageChecker.map.getOrElse("detach", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+    println("[Coverage - raise] - " + CoverageChecker.map.getOrElse("raise", sys.error(s"unexpected key")).mkString("[",", ", "]")) 
   }
 }


### PR DESCRIPTION
This commit introduces the possibility to check the coverage of branches for raise in util/Promise.scala via the AdHoc CoverageChecker. A print of the branches are added to the test suite as well. This resolves #8.

[Issue: #8]