### PR TITLE
[feat ]Add CoverageChecker to setInterruptHandler in util/Promise.scala

### DIFF
--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -513,31 +513,35 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
     val funcName = "setInterruptHandler"
     CoverageChecker.initialize(funcName, 9)
     state match {
-      case waitq: WaitQueue[A] => {
-        CoverageChecker.reached(funcName, 0)
+      case waitq: WaitQueue[A] => {        
         if (!cas(waitq, new Interruptible(waitq, f, Local.save()))) {
-          CoverageChecker.reached(funcName, 1)
+          CoverageChecker.reached(funcName, 0)
           setInterruptHandler(f)
+        }
+        else {
+          CoverageChecker.reached(funcName, 1)
         }
       }
 
       case s: Interruptible[A] => {
-        CoverageChecker.reached(funcName, 2)
         if (!cas(s, new Interruptible(s.waitq, f, Local.save()))) {
-          CoverageChecker.reached(funcName, 3)
+          CoverageChecker.reached(funcName, 2)
           setInterruptHandler(f)
         }
+        else {
+          CoverageChecker.reached(funcName, 3)
+        }
       }
-
 
       case s: Transforming[A] => {
-        CoverageChecker.reached(funcName, 4)
         if (!cas(s, new Interruptible(s.waitq, f, Local.save()))) {
-          CoverageChecker.reached(funcName, 5)
+          CoverageChecker.reached(funcName, 4)
           setInterruptHandler(f)
         }
+        else {
+          CoverageChecker.reached(funcName, 5)
+        }
       }
-
 
       case s: Interrupted[A] => {
         CoverageChecker.reached(funcName, 6)

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -509,25 +509,51 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
    * @param f the new interrupt handler
    */
   @tailrec
-  final def setInterruptHandler(f: PartialFunction[Throwable, Unit]): Unit = state match {
-    case waitq: WaitQueue[A] =>
-      if (!cas(waitq, new Interruptible(waitq, f, Local.save())))
-        setInterruptHandler(f)
+  final def setInterruptHandler(f: PartialFunction[Throwable, Unit]): Unit = {
+    val funcName = "setInterruptHandler"
+    CoverageChecker.initialize(funcName, 9)
+    state match {
+      case waitq: WaitQueue[A] => {
+        CoverageChecker.reached(funcName, 0)
+        if (!cas(waitq, new Interruptible(waitq, f, Local.save()))) {
+          CoverageChecker.reached(funcName, 1)
+          setInterruptHandler(f)
+        }
+      }
 
-    case s: Interruptible[A] =>
-      if (!cas(s, new Interruptible(s.waitq, f, Local.save())))
-        setInterruptHandler(f)
+      case s: Interruptible[A] => {
+        CoverageChecker.reached(funcName, 2)
+        if (!cas(s, new Interruptible(s.waitq, f, Local.save()))) {
+          CoverageChecker.reached(funcName, 3)
+          setInterruptHandler(f)
+        }
+      }
 
-    case s: Transforming[A] =>
-      if (!cas(s, new Interruptible(s.waitq, f, Local.save())))
-        setInterruptHandler(f)
 
-    case s: Interrupted[A] =>
-      f.applyOrElse(s.signal, Promise.AlwaysUnit)
+      case s: Transforming[A] => {
+        CoverageChecker.reached(funcName, 4)
+        if (!cas(s, new Interruptible(s.waitq, f, Local.save()))) {
+          CoverageChecker.reached(funcName, 5)
+          setInterruptHandler(f)
+        }
+      }
 
-    case _: Try[A] /* Done */ => // ignore
 
-    case p: Promise[A] /* Linked */ => p.setInterruptHandler(f)
+      case s: Interrupted[A] => {
+        CoverageChecker.reached(funcName, 6)
+        f.applyOrElse(s.signal, Promise.AlwaysUnit)
+      }
+        
+      case _: Try[A] /* Done */ => {
+        // ignore
+        CoverageChecker.reached(funcName, 7)
+      }
+
+      case p: Promise[A] /* Linked */ => {
+        CoverageChecker.reached(funcName, 8)
+        p.setInterruptHandler(f)
+      }
+    }
   }
 
   // Useful for debugging waitq.

--- a/util-core/src/test/scala/com/twitter/util/DurationTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/DurationTest.scala
@@ -296,7 +296,7 @@ class DurationTest extends { val ops: Duration.type = Duration } with TimeLikeSp
 
   "CoverageChecker" should {
     "print map" in {
-      println("[Coverage - parse] - " + CoverageChecker.map.getOrElse("parse", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+      println(CoverageChecker.map.getOrElse("parse", sys.error(s"unexpected key")).mkString("[",", ", "]"))
     }
   }
 }

--- a/util-core/src/test/scala/com/twitter/util/DurationTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/DurationTest.scala
@@ -296,7 +296,7 @@ class DurationTest extends { val ops: Duration.type = Duration } with TimeLikeSp
 
   "CoverageChecker" should {
     "print map" in {
-      println(CoverageChecker.map.getOrElse("parse", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+      println("[Coverage - parse] - " + CoverageChecker.map.getOrElse("parse", sys.error(s"unexpected key")).mkString("[",", ", "]"))
     }
   }
 }

--- a/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
@@ -343,6 +343,7 @@ class PromiseTest extends FunSuite {
   }
 
   test("CoverageChecker") {
-    println("[Coverage] - " + CoverageChecker.map.getOrElse("detach", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+    println("[Coverage - detach] - " + CoverageChecker.map.getOrElse("detach", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+    println("[Coverage - setInterruptHandler] - " + CoverageChecker.map.getOrElse("setInterruptHandler", sys.error(s"unexpected key")).mkString("[",", ", "]"))
   }
 }


### PR DESCRIPTION
This PR adds coverage checking has been added to the method 'setInterruptHandler' in util/Promise.scala. Resolves #16 

[Issue: #16]