### PR TITLE
[Feat] Add CoverageChecker to updateIfEmpty in util/Promise.java (#15)

### DIFF
--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -810,7 +810,7 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
    */
   @tailrec
   final def updateIfEmpty(result: Try[A]): Boolean = {
-    CoverageChecker.initialize("updateIfEmpty", 14)
+    CoverageChecker.initialize("updateIfEmpty", 15)
     state match {
       case waitq: WaitQueue[A] =>
         CoverageChecker.reached("updateIfEmpty", 0)
@@ -861,6 +861,10 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
       case p: Promise[A] /* Linked */ =>
         CoverageChecker.reached("updateIfEmpty", 13)
         p.updateIfEmpty(result)
+
+      case _ => 
+        CoverageChecker.reached("updateIfEmpty", 14)
+        false
     }
   }
 

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -809,36 +809,59 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
    * @return true only if the result is updated, false if it was already set.
    */
   @tailrec
-  final def updateIfEmpty(result: Try[A]): Boolean = state match {
-    case waitq: WaitQueue[A] =>
-      if (!cas(waitq, result)) updateIfEmpty(result)
-      else {
-        waitq.runInScheduler(result)
-        true
-      }
+  final def updateIfEmpty(result: Try[A]): Boolean = {
+    CoverageChecker.initialize("updateIfEmpty", 14)
+    state match {
+      case waitq: WaitQueue[A] =>
+        CoverageChecker.reached("updateIfEmpty", 0)
+        if (!cas(waitq, result)){
+          CoverageChecker.reached("updateIfEmpty", 1)
+          updateIfEmpty(result)
+        } else {
+          CoverageChecker.reached("updateIfEmpty", 2)
+          waitq.runInScheduler(result)
+          true
+        }
 
-    case s: Interruptible[A] =>
-      if (!cas(s, result)) updateIfEmpty(result)
-      else {
-        s.waitq.runInScheduler(result)
-        true
-      }
-    case s: Transforming[A] =>
-      if (!cas(s, result)) updateIfEmpty(result)
-      else {
-        s.waitq.runInScheduler(result)
-        true
-      }
-    case s: Interrupted[A] =>
-      if (!cas(s, result)) updateIfEmpty(result)
-      else {
-        s.waitq.runInScheduler(result)
-        true
-      }
+      case s: Interruptible[A] =>
+        CoverageChecker.reached("updateIfEmpty", 3)
+        if (!cas(s, result)) {
+          CoverageChecker.reached("updateIfEmpty", 4)
+          updateIfEmpty(result)
+        } else {
+          CoverageChecker.reached("updateIfEmpty", 5)
+          s.waitq.runInScheduler(result)
+          true
+        }
+      case s: Transforming[A] =>
+        CoverageChecker.reached("updateIfEmpty", 6)
+        if (!cas(s, result)) {
+          CoverageChecker.reached("updateIfEmpty", 7)
+          updateIfEmpty(result)
+        } else {
+          CoverageChecker.reached("updateIfEmpty", 8)
+          s.waitq.runInScheduler(result)
+          true
+        }
+      case s: Interrupted[A] =>
+        CoverageChecker.reached("updateIfEmpty", 9)
+        if (!cas(s, result)) {
+          CoverageChecker.reached("updateIfEmpty", 10)
+          updateIfEmpty(result)
+        } else {
+          CoverageChecker.reached("updateIfEmpty", 11)
+          s.waitq.runInScheduler(result)
+          true
+        }
 
-    case _: Try[A] /* Done */ => false
+      case _: Try[A] /* Done */ =>
+        CoverageChecker.reached("updateIfEmpty", 12)
+        false
 
-    case p: Promise[A] /* Linked */ => p.updateIfEmpty(result)
+      case p: Promise[A] /* Linked */ =>
+        CoverageChecker.reached("updateIfEmpty", 13)
+        p.updateIfEmpty(result)
+    }
   }
 
   @tailrec

--- a/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
@@ -346,6 +346,7 @@ class PromiseTest extends FunSuite {
     println("[Coverage - continue] - " + CoverageChecker.map.getOrElse("continue", sys.error(s"unexpected key")).mkString("[",", ", "]"))
     println("[Coverage - link] - " + CoverageChecker.map.getOrElse("link", sys.error(s"unexpected key")).mkString("[",", ", "]"))
     println("[Coverage - detach] - " + CoverageChecker.map.getOrElse("detach", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+    println("[Coverage - updateIfEmpty] - " + CoverageChecker.map.getOrElse("updateIfEmpty", sys.error(s"unexpected key")).mkString("[",", ", "]"))
   }
 
 }


### PR DESCRIPTION
This commit introduces the possibility to check the coverage of branches for updateIfEmpty in util/Promise.scala via the AdHoc CoverageChecker. A print of the branches is added to the test suite as well. This resolves #15.

[Issue: #15]