### PR TITLE
[feat] Add test for method 'parse' in util/Duration.scala

### DIFF
--- a/util-core/src/test/scala/com/twitter/util/DurationTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/DurationTest.scala
@@ -285,6 +285,16 @@ class DurationTest extends { val ops: Duration.type = Duration } with TimeLikeSp
         }
       }
     }
+
+    "throw on invalid unit" in {
+      intercept[NumberFormatException] {
+        Seq(
+          "1.minutes + 5.secundos"
+        ) foreach { s => 
+          Duration.parse(s)
+        }
+      }
+    }
   }
 
   "Top" should {


### PR DESCRIPTION
This commit adds a test for the case when an invalid TimeUnit is used. Resolves #28

[Issue: #28]