### PR TITLE
[feat] Add test for Some case in Config.collect

### DIFF
--- a/util-core/src/test/scala/com/twitter/util/ConfigTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/ConfigTest.scala
@@ -45,6 +45,13 @@ class ConfigTest extends WordSpec with Matchers {
       var bar = required[Bar]
       var baz = optional[Baz]
     }
+    class Bat extends Foo {
+      def fn(): Option[Bat] = {
+        // Fill potentially missing value when method is called
+        x = 0
+        this
+      }
+    }
 
     "missingValues" should {
       "must return empty Seq when no values are missing" in {
@@ -67,6 +74,14 @@ class ConfigTest extends WordSpec with Matchers {
           bar = new Bar
         }
         assert(foo.missingValues.sorted == Seq("x", "bar.z").sorted)
+      }
+
+      "must reinvoke collect when nullary method returns Some" in {
+        val bat = new Bat {
+          bar = new Bar
+        }
+        // The change in state from bat.fn being executed should lead to "x" not being missing
+        assert(bat.missingValues.sorted == Seq("bar.z"))
       }
 
       "must find nested missing values in optional sub-configs" in {


### PR DESCRIPTION
The method Config.collect was previously missing test coverage for the
case where an invoked method returns Some(Config[_]). In this case, the
program is supposed to unwrap the monad and recursively search for
missing values in the inner configuration. This has been tested by
adding a simple class method that populates a missing value if executed
and then returns itself, wrapped in an Option monad. If the program
recurses after executing the method, it will find the populated missing
value. If it does not, the value will still be missing.

Resolves #29

[Issue: #29]