### PR TITLE
[feat] Add test of default case in Config.collect

### DIFF
--- a/util-core/src/test/scala/com/twitter/util/ConfigTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/ConfigTest.scala
@@ -45,6 +45,13 @@ class ConfigTest extends WordSpec with Matchers {
       var bar = required[Bar]
       var baz = optional[Baz]
     }
+    class Qux extends Foo {
+      def fn(): Option[Bat] = {
+        // Fill potentially missing value when method is called
+        x = 0
+        None
+      }
+    }
 
     "missingValues" should {
       "must return empty Seq when no values are missing" in {
@@ -82,6 +89,15 @@ class ConfigTest extends WordSpec with Matchers {
         // this code is deprecated and we want to stop supporting it.
         // so we simplify the test.
         assert(foo.missingValues.contains("baz.w"))
+      }
+      
+      "must not reinvoke collect in default case of invocation" in {
+        val qux = new Qux {
+          bar = new Bar
+        }
+        // x should still be missing despite the change in state from bat.fn being executed as
+        // the collect method shouldn't be re-invoked
+        assert(qux.missingValues.sorted == Seq("x", "bar.z").sorted)
       }
     }
   }

--- a/util-core/src/test/scala/com/twitter/util/ConfigTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/ConfigTest.scala
@@ -46,7 +46,7 @@ class ConfigTest extends WordSpec with Matchers {
       var baz = optional[Baz]
     }
     class Qux extends Foo {
-      def fn(): Option[Bat] = {
+      def fn(): Option[Qux] = {
         // Fill potentially missing value when method is called
         x = 0
         None

--- a/util-core/src/test/scala/com/twitter/util/ConfigTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/ConfigTest.scala
@@ -45,12 +45,8 @@ class ConfigTest extends WordSpec with Matchers {
       var bar = required[Bar]
       var baz = optional[Baz]
     }
-    class Qux extends Foo {
-      def fn(): Option[Qux] = {
-        // Fill potentially missing value when method is called
-        x = 0
-        None
-      }
+    class Qux extends Config.Nothing {
+      var baz = required[Option[Baz]]
     }
 
     "missingValues" should {
@@ -91,13 +87,11 @@ class ConfigTest extends WordSpec with Matchers {
         assert(foo.missingValues.contains("baz.w"))
       }
       
-      "must not reinvoke collect in default case of invocation" in {
+      "must not search sub-configs that are None wrapped in Option" in {
         val qux = new Qux {
-          bar = new Bar
+          baz = None
         }
-        // x should still be missing despite the change in state from bat.fn being executed as
-        // the collect method shouldn't be re-invoked
-        assert(qux.missingValues.sorted == Seq("x", "bar.z").sorted)
+        assert(qux.missingValues.isEmpty)
       }
     }
   }


### PR DESCRIPTION
The method Config.collect was previously missing test coverage for the
case where an invoked method did not return a value that matched any
case, thus leading to an empty default case. In this situation, the
method is not supposed to recursively re-invoke the collect method. This
is tested by having a method that populates a defaulted value and
returns None, leading to a situation where if the buffer is recursively
checked again after the method has been invoked, the test will fail.

Resolves #30 

[Issue: #30]