### PR TITLE
[feat] Add CoverageChecker to equals 

### DIFF
--- a/util-core/src/main/scala/com/twitter/io/Buf.scala
+++ b/util-core/src/main/scala/com/twitter/io/Buf.scala
@@ -576,9 +576,13 @@ object Buf {
                 val otherB = otherBufs(otherBufIdx)
                 while (byteIdx < buf.length && otherByteIdx < otherB.length) {
                   CoverageChecker.reached(funcName, 3)
-                  if (buf.get(byteIdx) != otherB.get(otherByteIdx))
+                  if (buf.get(byteIdx) != otherB.get(otherByteIdx)){
                     CoverageChecker.reached(funcName, 4)
                     return false
+                  }
+                  else {
+                    CoverageChecker.reached(funcName, 4)
+                  }
                   byteIdx += 1
                   otherByteIdx += 1
                 }
@@ -587,10 +591,16 @@ object Buf {
                   byteIdx = 0
                   bufIdx += 1
                 }
+                else {
+                  CoverageChecker.reached(funcName, 5)
+                }
                 if (otherByteIdx == otherB.length) {
                   CoverageChecker.reached(funcName, 6)
                   otherByteIdx = 0
                   otherBufIdx += 1
+                }
+                else {
+                  CoverageChecker.reached(funcName, 6)
                 }
               }
               true
@@ -598,12 +608,14 @@ object Buf {
             case _ => {
               CoverageChecker.reached(funcName, 7)
               otherBuf.unsafeByteArrayBuf match {
-                case Some(otherBab) =>
+                case Some(otherBab) => {
                   CoverageChecker.reached(funcName, 8)
                   equalsIndexed(otherBab)
-                case None =>
+                }                  
+                case None => {
                   CoverageChecker.reached(funcName, 9)
                   equalsIndexed(otherBuf)
+                }
               }
             }
               

--- a/util-core/src/main/scala/com/twitter/io/Buf.scala
+++ b/util-core/src/main/scala/com/twitter/io/Buf.scala
@@ -556,7 +556,7 @@ object Buf {
 
     override def equals(other: Any): Boolean = {
       val funcName = "equals"
-      CoverageChecker.initialize(funcName, 11)
+      CoverageChecker.initialize(funcName, 13)
       other match {
         case otherBuf: Buf if length == otherBuf.length => {
           CoverageChecker.reached(funcName, 0)
@@ -581,39 +581,39 @@ object Buf {
                     return false
                   }
                   else {
-                    CoverageChecker.reached(funcName, 4)
+                    CoverageChecker.reached(funcName, 5)
                   }
                   byteIdx += 1
                   otherByteIdx += 1
                 }
                 if (byteIdx == buf.length) {
-                  CoverageChecker.reached(funcName, 5)
+                  CoverageChecker.reached(funcName, 6)
                   byteIdx = 0
                   bufIdx += 1
                 }
                 else {
-                  CoverageChecker.reached(funcName, 5)
+                  CoverageChecker.reached(funcName, 7)
                 }
                 if (otherByteIdx == otherB.length) {
-                  CoverageChecker.reached(funcName, 6)
+                  CoverageChecker.reached(funcName, 8)
                   otherByteIdx = 0
                   otherBufIdx += 1
                 }
                 else {
-                  CoverageChecker.reached(funcName, 6)
+                  CoverageChecker.reached(funcName, 9)
                 }
               }
               true
 
             case _ => {
-              CoverageChecker.reached(funcName, 7)
+              CoverageChecker.reached(funcName, 10)
               otherBuf.unsafeByteArrayBuf match {
                 case Some(otherBab) => {
-                  CoverageChecker.reached(funcName, 8)
+                  CoverageChecker.reached(funcName, 11)
                   equalsIndexed(otherBab)
                 }                  
                 case None => {
-                  CoverageChecker.reached(funcName, 9)
+                  CoverageChecker.reached(funcName, 12)
                   equalsIndexed(otherBuf)
                 }
               }

--- a/util-core/src/main/scala/com/twitter/io/Buf.scala
+++ b/util-core/src/main/scala/com/twitter/io/Buf.scala
@@ -554,63 +554,66 @@ object Buf {
       true
     }
 
-    override def equals(other: Any): Boolean = other match {
+    override def equals(other: Any): Boolean = {
       val funcName = "equals"
-      CoverageChecker.initialize(funcName, 13)
-      case otherBuf: Buf if length == otherBuf.length =>
-        CoverageChecker.reached(funcName, 0)
-        otherBuf match {
-          CoverageChecker.reached(funcName, 1)
-          case Composite(otherBufs, _) =>
-            CoverageChecker.reached(funcName, 2)
-            // this is 2 nested loops, with the outer loop tracking which
-            // Buf's they are on. The inner loop compares individual bytes across
-            // the Bufs "segments".
-            var otherBufIdx = 0
-            var bufIdx = 0
-            var byteIdx = 0
-            var otherByteIdx = 0
-            while (bufIdx < bufs.length && otherBufIdx < otherBufs.length) {
-              CoverageChecker.reached(funcName, 3)
-              val buf = bufs(bufIdx)
-              val otherB = otherBufs(otherBufIdx)
-              while (byteIdx < buf.length && otherByteIdx < otherB.length) {
-                CoverageChecker.reached(funcName, 4)
-                if (buf.get(byteIdx) != otherB.get(otherByteIdx))
+      CoverageChecker.initialize(funcName, 11)
+      other match {
+        case otherBuf: Buf if length == otherBuf.length => {
+          CoverageChecker.reached(funcName, 0)
+          otherBuf match {
+            case Composite(otherBufs, _) =>
+              CoverageChecker.reached(funcName, 1)
+              // this is 2 nested loops, with the outer loop tracking which
+              // Buf's they are on. The inner loop compares individual bytes across
+              // the Bufs "segments".
+              var otherBufIdx = 0
+              var bufIdx = 0
+              var byteIdx = 0
+              var otherByteIdx = 0
+              while (bufIdx < bufs.length && otherBufIdx < otherBufs.length) {
+                CoverageChecker.reached(funcName, 2)
+                val buf = bufs(bufIdx)
+                val otherB = otherBufs(otherBufIdx)
+                while (byteIdx < buf.length && otherByteIdx < otherB.length) {
+                  CoverageChecker.reached(funcName, 3)
+                  if (buf.get(byteIdx) != otherB.get(otherByteIdx))
+                    CoverageChecker.reached(funcName, 4)
+                    return false
+                  byteIdx += 1
+                  otherByteIdx += 1
+                }
+                if (byteIdx == buf.length) {
                   CoverageChecker.reached(funcName, 5)
-                  return false
-                byteIdx += 1
-                otherByteIdx += 1
+                  byteIdx = 0
+                  bufIdx += 1
+                }
+                if (otherByteIdx == otherB.length) {
+                  CoverageChecker.reached(funcName, 6)
+                  otherByteIdx = 0
+                  otherBufIdx += 1
+                }
               }
-              if (byteIdx == buf.length) {
-                CoverageChecker.reached(funcName, 6)
-                byteIdx = 0
-                bufIdx += 1
-              }
-              if (otherByteIdx == otherB.length) {
-                CoverageChecker.reached(funcName, 7)
-                otherByteIdx = 0
-                otherBufIdx += 1
-              }
-            }
-            true
+              true
 
-          case _ =>
-            CoverageChecker.reached(funcName, 8)
-            otherBuf.unsafeByteArrayBuf match {
-              CoverageChecker.reached(funcName, 9)
-              case Some(otherBab) =>
-                CoverageChecker.reached(funcName, 10)
-                equalsIndexed(otherBab)
-              case None =>
-                CoverageChecker.reached(funcName, 11)
-                equalsIndexed(otherBuf)
+            case _ => {
+              CoverageChecker.reached(funcName, 7)
+              otherBuf.unsafeByteArrayBuf match {
+                case Some(otherBab) =>
+                  CoverageChecker.reached(funcName, 8)
+                  equalsIndexed(otherBab)
+                case None =>
+                  CoverageChecker.reached(funcName, 9)
+                  equalsIndexed(otherBuf)
+              }
             }
+              
+          }
         }
 
-      case _ =>
-        CoverageChecker.reached(funcName, 12)
-        false
+        case _ =>
+          CoverageChecker.reached(funcName, 10)
+          false
+      }
     }
   }
 

--- a/util-core/src/main/scala/com/twitter/io/Buf.scala
+++ b/util-core/src/main/scala/com/twitter/io/Buf.scala
@@ -5,6 +5,7 @@ import java.nio.ReadOnlyBufferException
 import java.nio.charset.{Charset, StandardCharsets => JChar}
 import scala.annotation.switch
 import scala.collection.immutable.VectorBuilder
+import com.twitter.util.CoverageChecker
 
 /**
  * Buf represents a fixed, immutable byte buffer with efficient
@@ -554,9 +555,14 @@ object Buf {
     }
 
     override def equals(other: Any): Boolean = other match {
+      val funcName = "equals"
+      CoverageChecker.initialize(funcName, 13)
       case otherBuf: Buf if length == otherBuf.length =>
+        CoverageChecker.reached(funcName, 0)
         otherBuf match {
+          CoverageChecker.reached(funcName, 1)
           case Composite(otherBufs, _) =>
+            CoverageChecker.reached(funcName, 2)
             // this is 2 nested loops, with the outer loop tracking which
             // Buf's they are on. The inner loop compares individual bytes across
             // the Bufs "segments".
@@ -565,19 +571,24 @@ object Buf {
             var byteIdx = 0
             var otherByteIdx = 0
             while (bufIdx < bufs.length && otherBufIdx < otherBufs.length) {
+              CoverageChecker.reached(funcName, 3)
               val buf = bufs(bufIdx)
               val otherB = otherBufs(otherBufIdx)
               while (byteIdx < buf.length && otherByteIdx < otherB.length) {
+                CoverageChecker.reached(funcName, 4)
                 if (buf.get(byteIdx) != otherB.get(otherByteIdx))
+                  CoverageChecker.reached(funcName, 5)
                   return false
                 byteIdx += 1
                 otherByteIdx += 1
               }
               if (byteIdx == buf.length) {
+                CoverageChecker.reached(funcName, 6)
                 byteIdx = 0
                 bufIdx += 1
               }
               if (otherByteIdx == otherB.length) {
+                CoverageChecker.reached(funcName, 7)
                 otherByteIdx = 0
                 otherBufIdx += 1
               }
@@ -585,15 +596,20 @@ object Buf {
             true
 
           case _ =>
+            CoverageChecker.reached(funcName, 8)
             otherBuf.unsafeByteArrayBuf match {
+              CoverageChecker.reached(funcName, 9)
               case Some(otherBab) =>
+                CoverageChecker.reached(funcName, 10)
                 equalsIndexed(otherBab)
               case None =>
+                CoverageChecker.reached(funcName, 11)
                 equalsIndexed(otherBuf)
             }
         }
 
       case _ =>
+        CoverageChecker.reached(funcName, 12)
         false
     }
   }

--- a/util-core/src/test/scala/com/twitter/io/BufTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/BufTest.scala
@@ -12,6 +12,7 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatestplus.scalacheck.Checkers
 import scala.collection.mutable
 import java.nio.charset.Charset
+import com.twitter.util.CoverageChecker
 
 class BufTest
     extends FunSuite
@@ -1009,5 +1010,9 @@ class BufTest
       assert(constructor == concatLeft)
       assert(constructor == concatRight)
     }
+  }
+
+  test("CoverageChecker") {
+    println("[Coverage - equals] - " + CoverageChecker.map.getOrElse("equals", sys.error(s"unexpected key")).mkString("[",", ", "]"))
   }
 }


### PR DESCRIPTION
This PR adds coverage checking for the function 'equals' in io/Buf.scala. Resloves #9  

[Issue: #9]