### PR TITLE
Add CoverageChecker to ipToOptionInt in util/NetUtil.scala

### DIFF
--- a/util-core/src/main/scala/com/twitter/io/Buf.scala
+++ b/util-core/src/main/scala/com/twitter/io/Buf.scala
@@ -5,6 +5,7 @@ import java.nio.ReadOnlyBufferException
 import java.nio.charset.{Charset, StandardCharsets => JChar}
 import scala.annotation.switch
 import scala.collection.immutable.VectorBuilder
+import com.twitter.util.CoverageChecker
 
 /**
  * Buf represents a fixed, immutable byte buffer with efficient
@@ -553,48 +554,78 @@ object Buf {
       true
     }
 
-    override def equals(other: Any): Boolean = other match {
-      case otherBuf: Buf if length == otherBuf.length =>
-        otherBuf match {
-          case Composite(otherBufs, _) =>
-            // this is 2 nested loops, with the outer loop tracking which
-            // Buf's they are on. The inner loop compares individual bytes across
-            // the Bufs "segments".
-            var otherBufIdx = 0
-            var bufIdx = 0
-            var byteIdx = 0
-            var otherByteIdx = 0
-            while (bufIdx < bufs.length && otherBufIdx < otherBufs.length) {
-              val buf = bufs(bufIdx)
-              val otherB = otherBufs(otherBufIdx)
-              while (byteIdx < buf.length && otherByteIdx < otherB.length) {
-                if (buf.get(byteIdx) != otherB.get(otherByteIdx))
-                  return false
-                byteIdx += 1
-                otherByteIdx += 1
+    override def equals(other: Any): Boolean = {
+      val funcName = "equals"
+      CoverageChecker.initialize(funcName, 13)
+      other match {
+        case otherBuf: Buf if length == otherBuf.length => {
+          CoverageChecker.reached(funcName, 0)
+          otherBuf match {
+            case Composite(otherBufs, _) =>
+              CoverageChecker.reached(funcName, 1)
+              // this is 2 nested loops, with the outer loop tracking which
+              // Buf's they are on. The inner loop compares individual bytes across
+              // the Bufs "segments".
+              var otherBufIdx = 0
+              var bufIdx = 0
+              var byteIdx = 0
+              var otherByteIdx = 0
+              while (bufIdx < bufs.length && otherBufIdx < otherBufs.length) {
+                CoverageChecker.reached(funcName, 2)
+                val buf = bufs(bufIdx)
+                val otherB = otherBufs(otherBufIdx)
+                while (byteIdx < buf.length && otherByteIdx < otherB.length) {
+                  CoverageChecker.reached(funcName, 3)
+                  if (buf.get(byteIdx) != otherB.get(otherByteIdx)){
+                    CoverageChecker.reached(funcName, 4)
+                    return false
+                  }
+                  else {
+                    CoverageChecker.reached(funcName, 5)
+                  }
+                  byteIdx += 1
+                  otherByteIdx += 1
+                }
+                if (byteIdx == buf.length) {
+                  CoverageChecker.reached(funcName, 6)
+                  byteIdx = 0
+                  bufIdx += 1
+                }
+                else {
+                  CoverageChecker.reached(funcName, 7)
+                }
+                if (otherByteIdx == otherB.length) {
+                  CoverageChecker.reached(funcName, 8)
+                  otherByteIdx = 0
+                  otherBufIdx += 1
+                }
+                else {
+                  CoverageChecker.reached(funcName, 9)
+                }
               }
-              if (byteIdx == buf.length) {
-                byteIdx = 0
-                bufIdx += 1
-              }
-              if (otherByteIdx == otherB.length) {
-                otherByteIdx = 0
-                otherBufIdx += 1
-              }
-            }
-            true
+              true
 
-          case _ =>
-            otherBuf.unsafeByteArrayBuf match {
-              case Some(otherBab) =>
-                equalsIndexed(otherBab)
-              case None =>
-                equalsIndexed(otherBuf)
+            case _ => {
+              CoverageChecker.reached(funcName, 10)
+              otherBuf.unsafeByteArrayBuf match {
+                case Some(otherBab) => {
+                  CoverageChecker.reached(funcName, 11)
+                  equalsIndexed(otherBab)
+                }                  
+                case None => {
+                  CoverageChecker.reached(funcName, 12)
+                  equalsIndexed(otherBuf)
+                }
+              }
             }
+              
+          }
         }
 
-      case _ =>
-        false
+        case _ =>
+          CoverageChecker.reached(funcName, 10)
+          false
+      }
     }
   }
 

--- a/util-core/src/main/scala/com/twitter/util/Config.scala
+++ b/util-core/src/main/scala/com/twitter/util/Config.scala
@@ -19,6 +19,7 @@ package com.twitter.util
 import java.io.Serializable
 import scala.collection.mutable
 import scala.language.implicitConversions
+import com.twitter.util.CoverageChecker;
 
 /**
  * You can import Config._ if you want the auto-conversions in a class
@@ -134,43 +135,65 @@ trait Config[T] extends (() => T) {
     val buf = new mutable.ListBuffer[String]
     val mirror = scala.reflect.runtime.universe.runtimeMirror(getClass.getClassLoader)
     def collect(prefix: String, config: Config[_]): Unit = {
+      CoverageChecker.initialize("collect", 14)
       if (!alreadyVisited.contains(config)) {
+        CoverageChecker.reached("collect", 0)
         alreadyVisited += config
         val nullaryMethods = config.getClass.getMethods.toSeq filter { _.getParameterTypes.isEmpty }
         val syntheticTermNames: Set[String] = {
           val configSymbol = mirror.reflect(config).symbol
           val configMembers = configSymbol.toType.members
           configMembers.iterator.collect {
-            case symbol if symbol.isTerm && symbol.isSynthetic =>
+            case symbol if symbol.isTerm && symbol.isSynthetic => {
+              CoverageChecker.reached("collect", 1)
               symbol.name.decodedName.toString
+            }
           }.toSet
         }
         for (method <- nullaryMethods) {
+          CoverageChecker.reached("collect", 2)
           val name = method.getName
           val rt = method.getReturnType
           if (name != "required" &&
             name != "optional" &&
             !syntheticTermNames.contains(name) && // no loops, no compiler generated methods!
             interestingReturnTypes.exists(_.isAssignableFrom(rt))) {
+            CoverageChecker.reached("collect", 3)
             method.invoke(config) match {
-              case Unspecified =>
+              case Unspecified => {
+                CoverageChecker.reached("collect", 4)
                 buf += (prefix + name)
-              case specified: Specified[_] =>
+              }
+              case specified: Specified[_] => {
+                CoverageChecker.reached("collect", 5)
                 specified match {
-                  case Specified(sub: Config[_]) =>
+                  case Specified(sub: Config[_]) => {
+                    CoverageChecker.reached("collect", 6)
                     collect(prefix + name + ".", sub)
-                  case Specified(Some(sub: Config[_])) =>
+                  }
+                  case Specified(Some(sub: Config[_])) => {
+                    CoverageChecker.reached("collect", 7)
                     collect(prefix + name + ".", sub)
-                  case _ =>
+                  }
+                  case _ => CoverageChecker.reached("collect", 8)
                 }
-              case sub: Config[_] =>
+              }
+              case sub: Config[_] => {
+                CoverageChecker.reached("collect", 9)
                 collect(prefix + name + ".", sub)
-              case Some(sub: Config[_]) =>
+              }
+              case Some(sub: Config[_]) => {
+                CoverageChecker.reached("collect", 10)
                 collect(prefix + name + ".", sub)
-              case _ =>
+              }
+              case _ => CoverageChecker.reached("collect", 11)
             }
+          } else {
+            CoverageChecker.reached("collect", 12)
           }
         }
+      } else {
+        CoverageChecker.reached("collect", 13)
       }
     }
     collect("", this)

--- a/util-core/src/main/scala/com/twitter/util/CoverageChecker.scala
+++ b/util-core/src/main/scala/com/twitter/util/CoverageChecker.scala
@@ -1,0 +1,18 @@
+package com.twitter.util
+
+import scala.collection.mutable.HashMap
+
+object CoverageChecker {
+    val map: HashMap[String, Array[Boolean]] = new HashMap()
+    def initialize(functionName: String, branchCount: Integer): Unit = {
+        if (!map.contains(functionName)) {
+            map += (functionName -> new Array(branchCount))
+        }
+    }
+
+    def reached(functionName: String, branch: Integer): Unit = {
+        var reachedBranches = map.getOrElse(functionName, sys.error(s"unexpected key: $functionName"))
+        reachedBranches(branch) = true
+        map += (functionName -> reachedBranches)
+    }
+}

--- a/util-core/src/main/scala/com/twitter/util/CoverageExample.scala
+++ b/util-core/src/main/scala/com/twitter/util/CoverageExample.scala
@@ -1,0 +1,13 @@
+package com.twitter.util
+
+import com.twitter.util._
+
+object CoverageExample {
+  def main (args: Array[String] ): Unit = {
+    CoverageChecker.initialize("f1", 5)
+    CoverageChecker.initialize("f2", 2)
+    CoverageChecker.reached("f1", 3)
+    println(CoverageChecker.map.getOrElse("f1", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+    println(CoverageChecker.map.getOrElse("f2", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+  }
+}

--- a/util-core/src/main/scala/com/twitter/util/Duration.scala
+++ b/util-core/src/main/scala/com/twitter/util/Duration.scala
@@ -223,38 +223,58 @@ object Duration extends TimeLikeOps[Duration] {
    * @throws RuntimeException if the string cannot be parsed.
    */
   def parse(s: String): Duration = {
+    CoverageChecker.initialize("parse", 11)
     val ss = s.toLowerCase
     ss match {
       case FullDurationRegex(_*) =>
+        CoverageChecker.reached("parse", 0)
         SingleDurationRegex.findAllIn(ss).matchData.zipWithIndex map {
           case (m, i) =>
+            CoverageChecker.reached("parse", 1)
             val List(signStr, numStr, unitStr, special) = m.subgroups
             val absDuration = special match {
-              case "top" => Top
-              case "bottom" => Bottom
-              case "undefined" => Undefined
+              case "top" => 
+                CoverageChecker.reached("parse", 2)
+                Top
+              case "bottom" => 
+                CoverageChecker.reached("parse", 3)
+                Bottom
+              case "undefined" => 
+                CoverageChecker.reached("parse", 4)
+                Undefined
               case _ =>
                 val u = nameToUnit.get(unitStr) match {
-                  case Some(t) => t
-                  case None => throw new NumberFormatException("Invalid unit: " + unitStr)
+                  case Some(t) => 
+                    CoverageChecker.reached("parse", 5)
+                    t
+                  case None =>
+                    CoverageChecker.reached("parse", 6)
+                    throw new NumberFormatException("Invalid unit: " + unitStr)
                 }
                 Duration(numStr.toLong, u)
             }
 
             signStr match {
-              case "-" => -absDuration
+              case "-" => 
+                CoverageChecker.reached("parse", 7)
+                -absDuration
 
               // It's only OK to omit the sign for the first duration.
               case "" if i > 0 =>
+                CoverageChecker.reached("parse", 8)
                 throw new NumberFormatException("Expected a sign between durations")
 
-              case _ => absDuration
+              case _ =>
+                CoverageChecker.reached("parse", 9) 
+                absDuration
             }
 
           // It's OK to use reduce because the regex ensures that there is
           // at least one element
         } reduce { _ + _ }
-      case _ => throw new NumberFormatException("Invalid duration: " + s)
+      case _ =>
+        CoverageChecker.reached("parse", 10)
+        throw new NumberFormatException("Invalid duration: " + s)
     }
   }
 }

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -574,38 +574,72 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
     }
   }
 
-  @tailrec final def raise(intr: Throwable): Unit = state match {
-    case waitq: WaitQueue[A] =>
-      if (!cas(waitq, new Interrupted(waitq, intr)))
-        raise(intr)
-
-    case s: Interruptible[A] =>
-      if (!cas(s, new Interrupted(s.waitq, intr))) raise(intr)
-      else {
-        if (!UseLocalInInterruptible)
-          s.handler.applyOrElse(intr, Promise.AlwaysUnit)
-        else {
-          val current = Local.save()
-          if (current ne s.saved)
-            Local.restore(s.saved)
-          try s.handler.applyOrElse(intr, Promise.AlwaysUnit)
-          finally Local.restore(current)
+  @tailrec final def raise(intr: Throwable): Unit = {
+    val funcName = "raise"
+    CoverageChecker.initialize(funcName, 15)
+    state match {
+      case waitq: WaitQueue[A] =>
+        if (!cas(waitq, new Interrupted(waitq, intr))) {
+          CoverageChecker.reached(funcName, 0)
+          raise(intr)
+        } else {
+          CoverageChecker.reached(funcName, 1)
         }
-      }
-
-    case s: Transforming[A] =>
-      if (!cas(s, new Interrupted(s.waitq, intr))) raise(intr)
-      else {
-        s.other.raise(intr)
-      }
-
-    case s: Interrupted[A] =>
-      if (!cas(s, new Interrupted(s.waitq, intr)))
-        raise(intr)
-
-    case _: Try[A] /* Done */ => () // nothing to do, as its already satisfied.
-
-    case p: Promise[A] /* Linked */ => p.raise(intr)
+  
+      case s: Interruptible[A] =>
+        if (!cas(s, new Interrupted(s.waitq, intr))) {
+          CoverageChecker.reached(funcName, 2)
+          raise(intr)
+        } else {
+          CoverageChecker.reached(funcName, 3)
+          if (!UseLocalInInterruptible) {
+            CoverageChecker.reached(funcName, 4)
+            s.handler.applyOrElse(intr, Promise.AlwaysUnit)
+          } else {
+            CoverageChecker.reached(funcName, 5)
+            val current = Local.save()
+            if (current ne s.saved) {
+              CoverageChecker.reached(funcName, 6)
+              Local.restore(s.saved)
+            } else {
+              CoverageChecker.reached(funcName, 7)
+            }
+            try {
+              s.handler.applyOrElse(intr, Promise.AlwaysUnit)
+            } catch {
+              case e: Throwable => 
+                CoverageChecker.reached(funcName, 8) 
+                throw e
+            } finally {
+              Local.restore(current)
+            }
+          }
+        }
+  
+      case s: Transforming[A] =>
+        if (!cas(s, new Interrupted(s.waitq, intr))) {
+          CoverageChecker.reached(funcName, 9)
+          raise(intr)
+        } else {
+          CoverageChecker.reached(funcName, 10)
+          s.other.raise(intr)
+        }
+  
+      case s: Interrupted[A] =>
+        if (!cas(s, new Interrupted(s.waitq, intr))) {
+          CoverageChecker.reached(funcName, 11)
+          raise(intr)
+        } else {
+          CoverageChecker.reached(funcName, 12)
+        }
+      case _: Try[A] /* Done */ => 
+        CoverageChecker.reached(funcName, 13)
+        () // nothing to do, as its already satisfied.
+  
+      case p: Promise[A] /* Linked */ => 
+        CoverageChecker.reached(funcName, 14)
+        p.raise(intr)      
+    }
   }
 
   @tailrec protected[Promise] final def detach(k: K[A]): Boolean = {

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -1,6 +1,7 @@
 package com.twitter.util
 
 import com.twitter.concurrent.Scheduler
+import com.twitter.util.CoverageChecker
 import scala.annotation.tailrec
 import scala.runtime.NonLocalReturnControl
 import scala.util.control.NonFatal
@@ -875,42 +876,79 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
 
   @tailrec
   protected final def link(target: Promise[A]): Unit = {
-    if (this eq target) return
+    val funcName = "link"
+    CoverageChecker.initialize(funcName, 19)
+    if (this eq target) {
+      CoverageChecker.reached(funcName, 0)
+      return
+    }
 
     state match {
       case waitq: WaitQueue[A] =>
-        if (!cas(waitq, target)) link(target)
-        else target.continueAll(waitq)
-
-      case s: Interruptible[A] =>
-        if (!cas(s, target)) link(target)
+        CoverageChecker.reached(funcName, 1)
+        if (!cas(waitq, target)) {
+          CoverageChecker.reached(funcName, 2)
+          link(target)
+        }
         else {
+          CoverageChecker.reached(funcName, 3)
+          target.continueAll(waitq)
+        }
+      case s: Interruptible[A] =>
+        CoverageChecker.reached(funcName, 4)
+        if (!cas(s, target)) {
+          CoverageChecker.reached(funcName, 5)
+          link(target)
+        }
+        else {
+          CoverageChecker.reached(funcName, 6)
           target.continueAll(s.waitq)
           target.setInterruptHandler(s.handler)
         }
 
       case s: Transforming[A] =>
-        if (!cas(s, target)) link(target)
+        CoverageChecker.reached(funcName, 7)
+        if (!cas(s, target)) {
+          CoverageChecker.reached(funcName, 8)
+          link(target)
+        }
         else {
+          CoverageChecker.reached(funcName, 9)
           target.continueAll(s.waitq)
           target.forwardInterruptsTo(s.other)
         }
 
       case s: Interrupted[A] =>
-        if (!cas(s, target)) link(target)
+        CoverageChecker.reached(funcName, 10)
+        if (!cas(s, target)) {
+          CoverageChecker.reached(funcName, 11)
+          link(target)
+        }
         else {
+          CoverageChecker.reached(funcName, 12)
           target.continueAll(s.waitq)
           target.raise(s.signal)
         }
 
       case value: Try[A] /* Done */ =>
+        CoverageChecker.reached(funcName, 13)
         if (!target.updateIfEmpty(value) && value != Await.result(target)) {
+          CoverageChecker.reached(funcName, 14)
           throw new IllegalArgumentException("Cannot link two Done Promises with differing values")
+        } else {
+          CoverageChecker.reached(funcName, 15)
         }
 
       case p: Promise[A] /* Linked */ =>
-        if (cas(p, target)) p.link(target)
-        else link(target)
+        CoverageChecker.reached(funcName, 16)
+        if (cas(p, target)) {
+          CoverageChecker.reached(funcName, 17)
+          p.link(target)
+        }
+        else {
+          CoverageChecker.reached(funcName, 18)
+          link(target)
+        }
     }
   }
 

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -842,21 +842,50 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
   }
 
   @tailrec
-  protected final def continue(k: K[A]): Unit = state match {
-    case waitq: WaitQueue[A] =>
-      if (!cas(waitq, WaitQueue(k, waitq)))
-        continue(k)
-    case s: Interruptible[A] =>
-      if (!cas(s, new Interruptible(WaitQueue(k, s.waitq), s.handler, s.saved)))
-        continue(k)
-    case s: Transforming[A] =>
-      if (!cas(s, new Transforming(WaitQueue(k, s.waitq), s.other)))
-        continue(k)
-    case s: Interrupted[A] =>
-      if (!cas(s, new Interrupted(WaitQueue(k, s.waitq), s.signal)))
-        continue(k)
-    case v: Try[A] /* Done */ => k.runInScheduler(v)
-    case p: Promise[A] /* Linked */ => p.continue(k)
+  protected final def continue(k: K[A]): Unit = {
+    CoverageChecker.initialize("continue", 15)
+    state match {
+      case waitq: WaitQueue[A] =>
+        CoverageChecker.reached("continue", 0)
+        if (!cas(waitq, WaitQueue(k, waitq))) {
+          CoverageChecker.reached("continue", 1)
+          continue(k)
+        } else {
+          CoverageChecker.reached("continue", 2)
+        }
+      case s: Interruptible[A] =>
+        CoverageChecker.reached("continue", 3)
+        if (!cas(s, new Interruptible(WaitQueue(k, s.waitq), s.handler, s.saved))) {
+          CoverageChecker.reached("continue", 4)
+          continue(k)
+        } else {
+          CoverageChecker.reached("continue", 5)
+        }
+      case s: Transforming[A] =>
+        CoverageChecker.reached("continue", 6)
+        if (!cas(s, new Transforming(WaitQueue(k, s.waitq), s.other))) {
+          CoverageChecker.reached("continue", 7)
+          continue(k)
+        } else {
+          CoverageChecker.reached("continue", 8)
+        }
+      case s: Interrupted[A] =>
+        CoverageChecker.reached("continue", 9)
+        if (!cas(s, new Interrupted(WaitQueue(k, s.waitq), s.signal))) {
+          CoverageChecker.reached("continue", 10)
+          continue(k)
+        } else {
+          CoverageChecker.reached("continue", 11)
+        }
+      case v: Try[A] /* Done */ => 
+        CoverageChecker.reached("continue", 12)
+        k.runInScheduler(v)
+      case p: Promise[A] /* Linked */ => 
+        CoverageChecker.reached("continue", 13)
+        p.continue(k)
+      case _ => CoverageChecker.reached("continue", 14)
+    }
+
   }
 
   /**

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -510,25 +510,55 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
    * @param f the new interrupt handler
    */
   @tailrec
-  final def setInterruptHandler(f: PartialFunction[Throwable, Unit]): Unit = state match {
-    case waitq: WaitQueue[A] =>
-      if (!cas(waitq, new Interruptible(waitq, f, Local.save())))
-        setInterruptHandler(f)
+  final def setInterruptHandler(f: PartialFunction[Throwable, Unit]): Unit = {
+    val funcName = "setInterruptHandler"
+    CoverageChecker.initialize(funcName, 9)
+    state match {
+      case waitq: WaitQueue[A] => {        
+        if (!cas(waitq, new Interruptible(waitq, f, Local.save()))) {
+          CoverageChecker.reached(funcName, 0)
+          setInterruptHandler(f)
+        }
+        else {
+          CoverageChecker.reached(funcName, 1)
+        }
+      }
 
-    case s: Interruptible[A] =>
-      if (!cas(s, new Interruptible(s.waitq, f, Local.save())))
-        setInterruptHandler(f)
+      case s: Interruptible[A] => {
+        if (!cas(s, new Interruptible(s.waitq, f, Local.save()))) {
+          CoverageChecker.reached(funcName, 2)
+          setInterruptHandler(f)
+        }
+        else {
+          CoverageChecker.reached(funcName, 3)
+        }
+      }
 
-    case s: Transforming[A] =>
-      if (!cas(s, new Interruptible(s.waitq, f, Local.save())))
-        setInterruptHandler(f)
+      case s: Transforming[A] => {
+        if (!cas(s, new Interruptible(s.waitq, f, Local.save()))) {
+          CoverageChecker.reached(funcName, 4)
+          setInterruptHandler(f)
+        }
+        else {
+          CoverageChecker.reached(funcName, 5)
+        }
+      }
 
-    case s: Interrupted[A] =>
-      f.applyOrElse(s.signal, Promise.AlwaysUnit)
+      case s: Interrupted[A] => {
+        CoverageChecker.reached(funcName, 6)
+        f.applyOrElse(s.signal, Promise.AlwaysUnit)
+      }
+        
+      case _: Try[A] /* Done */ => {
+        // ignore
+        CoverageChecker.reached(funcName, 7)
+      }
 
-    case _: Try[A] /* Done */ => // ignore
-
-    case p: Promise[A] /* Linked */ => p.setInterruptHandler(f)
+      case p: Promise[A] /* Linked */ => {
+        CoverageChecker.reached(funcName, 8)
+        p.setInterruptHandler(f)
+      }
+    }
   }
 
   // Useful for debugging waitq.

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -5,6 +5,8 @@ import scala.annotation.tailrec
 import scala.runtime.NonLocalReturnControl
 import scala.util.control.NonFatal
 
+import com.twitter.util.CoverageChecker
+
 object Promise {
 
   // An experimental property that enables the interrupt handler
@@ -605,34 +607,57 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
     case p: Promise[A] /* Linked */ => p.raise(intr)
   }
 
-  @tailrec protected[Promise] final def detach(k: K[A]): Boolean = state match {
-    case waitq: WaitQueue[A] =>
-      if (!cas(waitq, waitq.remove(k)))
-        detach(k)
-      else
-        waitq.contains(k)
+  @tailrec protected[Promise] final def detach(k: K[A]): Boolean = {
+    CoverageChecker.initialize("detach", 10)
+    state match {
+      case waitq: WaitQueue[A] =>
+        if (!cas(waitq, waitq.remove(k))) {
+          CoverageChecker.reached("detach", 0)
+          detach(k)
+        }
+        else {
+          CoverageChecker.reached("detach", 1)
+          waitq.contains(k)
+        }
 
-    case s: Interruptible[A] =>
-      if (!cas(s, new Interruptible(s.waitq.remove(k), s.handler, s.saved)))
-        detach(k)
-      else
-        s.waitq.contains(k)
+      case s: Interruptible[A] =>
+        if (!cas(s, new Interruptible(s.waitq.remove(k), s.handler, s.saved))) {
+          CoverageChecker.reached("detach", 2)
+          detach(k)
+        }
+        else {
+          CoverageChecker.reached("detach", 3)
+          s.waitq.contains(k)
+        }
 
-    case s: Transforming[A] =>
-      if (!cas(s, new Transforming(s.waitq.remove(k), s.other)))
-        detach(k)
-      else
-        s.waitq.contains(k)
+      case s: Transforming[A] =>
+        if (!cas(s, new Transforming(s.waitq.remove(k), s.other))) {
+          CoverageChecker.reached("detach", 4)
+          detach(k)
+        }
+        else {
+          CoverageChecker.reached("detach", 5)
+          s.waitq.contains(k)
+        }
 
-    case s: Interrupted[A] =>
-      if (!cas(s, new Interrupted(s.waitq.remove(k), s.signal)))
-        detach(k)
-      else
-        s.waitq.contains(k)
+      case s: Interrupted[A] =>
+        if (!cas(s, new Interrupted(s.waitq.remove(k), s.signal))) {
+          CoverageChecker.reached("detach", 6)
+          detach(k)
+        }
+        else {
+          CoverageChecker.reached("detach", 7)
+          s.waitq.contains(k)
+        }
 
-    case _: Try[A] /* Done */ => false
+      case _: Try[A] /* Done */ =>
+        CoverageChecker.reached("detach", 8) 
+        false
 
-    case p: Promise[A] /* Linked */ => p.detach(k)
+      case p: Promise[A] /* Linked */ =>
+        CoverageChecker.reached("detach", 9) 
+        p.detach(k)
+    }
   }
 
   // Awaitable

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -809,36 +809,63 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
    * @return true only if the result is updated, false if it was already set.
    */
   @tailrec
-  final def updateIfEmpty(result: Try[A]): Boolean = state match {
-    case waitq: WaitQueue[A] =>
-      if (!cas(waitq, result)) updateIfEmpty(result)
-      else {
-        waitq.runInScheduler(result)
-        true
-      }
+  final def updateIfEmpty(result: Try[A]): Boolean = {
+    CoverageChecker.initialize("updateIfEmpty", 15)
+    state match {
+      case waitq: WaitQueue[A] =>
+        CoverageChecker.reached("updateIfEmpty", 0)
+        if (!cas(waitq, result)){
+          CoverageChecker.reached("updateIfEmpty", 1)
+          updateIfEmpty(result)
+        } else {
+          CoverageChecker.reached("updateIfEmpty", 2)
+          waitq.runInScheduler(result)
+          true
+        }
 
-    case s: Interruptible[A] =>
-      if (!cas(s, result)) updateIfEmpty(result)
-      else {
-        s.waitq.runInScheduler(result)
-        true
-      }
-    case s: Transforming[A] =>
-      if (!cas(s, result)) updateIfEmpty(result)
-      else {
-        s.waitq.runInScheduler(result)
-        true
-      }
-    case s: Interrupted[A] =>
-      if (!cas(s, result)) updateIfEmpty(result)
-      else {
-        s.waitq.runInScheduler(result)
-        true
-      }
+      case s: Interruptible[A] =>
+        CoverageChecker.reached("updateIfEmpty", 3)
+        if (!cas(s, result)) {
+          CoverageChecker.reached("updateIfEmpty", 4)
+          updateIfEmpty(result)
+        } else {
+          CoverageChecker.reached("updateIfEmpty", 5)
+          s.waitq.runInScheduler(result)
+          true
+        }
+      case s: Transforming[A] =>
+        CoverageChecker.reached("updateIfEmpty", 6)
+        if (!cas(s, result)) {
+          CoverageChecker.reached("updateIfEmpty", 7)
+          updateIfEmpty(result)
+        } else {
+          CoverageChecker.reached("updateIfEmpty", 8)
+          s.waitq.runInScheduler(result)
+          true
+        }
+      case s: Interrupted[A] =>
+        CoverageChecker.reached("updateIfEmpty", 9)
+        if (!cas(s, result)) {
+          CoverageChecker.reached("updateIfEmpty", 10)
+          updateIfEmpty(result)
+        } else {
+          CoverageChecker.reached("updateIfEmpty", 11)
+          s.waitq.runInScheduler(result)
+          true
+        }
 
-    case _: Try[A] /* Done */ => false
+      case _: Try[A] /* Done */ =>
+        CoverageChecker.reached("updateIfEmpty", 12)
+        false
 
-    case p: Promise[A] /* Linked */ => p.updateIfEmpty(result)
+      case p: Promise[A] /* Linked */ =>
+        CoverageChecker.reached("updateIfEmpty", 13)
+        p.updateIfEmpty(result)
+
+      case _ => 
+        CoverageChecker.reached("updateIfEmpty", 14)
+        false
+    }
   }
 
   @tailrec

--- a/util-core/src/main/scala/com/twitter/util/Promise.scala
+++ b/util-core/src/main/scala/com/twitter/util/Promise.scala
@@ -874,7 +874,7 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
    */
   @tailrec
   final def updateIfEmpty(result: Try[A]): Boolean = {
-    CoverageChecker.initialize("updateIfEmpty", 15)
+    CoverageChecker.initialize("updateIfEmpty", 14)
     state match {
       case waitq: WaitQueue[A] =>
         CoverageChecker.reached("updateIfEmpty", 0)
@@ -925,16 +925,12 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
       case p: Promise[A] /* Linked */ =>
         CoverageChecker.reached("updateIfEmpty", 13)
         p.updateIfEmpty(result)
-
-      case _ => 
-        CoverageChecker.reached("updateIfEmpty", 14)
-        false
     }
   }
 
   @tailrec
   protected final def continue(k: K[A]): Unit = {
-    CoverageChecker.initialize("continue", 15)
+    CoverageChecker.initialize("continue", 14)
     state match {
       case waitq: WaitQueue[A] =>
         CoverageChecker.reached("continue", 0)
@@ -974,7 +970,6 @@ class Promise[A] extends Future[A] with Promise.Responder[A] with Updatable[Try[
       case p: Promise[A] /* Linked */ => 
         CoverageChecker.reached("continue", 13)
         p.continue(k)
-      case _ => CoverageChecker.reached("continue", 14)
     }
 
   }

--- a/util-core/src/main/scala/com/twitter/util/Time.scala
+++ b/util-core/src/main/scala/com/twitter/util/Time.scala
@@ -20,6 +20,7 @@ import java.io.Serializable
 import java.time.{Clock, Instant}
 import java.util.concurrent.TimeUnit
 import java.util.{Date, Locale, TimeZone}
+import com.twitter.util.CoverageChecker
 
 /**
  * @define now
@@ -221,14 +222,37 @@ trait TimeLike[This <: TimeLike[This]] extends Ordered[This] { self: This =>
    * Time object with duration greater than 1.hour can have unexpected
    * results because of timezones.
    */
-  def floor(increment: Duration): This = (this, increment) match {
-    case (num, ns) if num.isZero && ns.isZero => ops.Undefined
-    case (num, ns) if num.isFinite && ns.isZero =>
-      if (num.inNanoseconds < 0) ops.Bottom else ops.Top
-    case (num, denom) if num.isFinite && denom.isFinite =>
-      ops.fromNanoseconds((num.inNanoseconds / denom.inNanoseconds) * denom.inNanoseconds)
-    case (self, n) if n.isFinite => self
-    case (_, _) => ops.Undefined
+  def floor(increment: Duration): This = {
+    val funcName = "floor"
+    CoverageChecker.initialize("floor", 7)
+    (this, increment) match {
+      case (num, ns) if num.isZero && ns.isZero => {
+        CoverageChecker.reached("floor", 0)
+        ops.Undefined
+      }
+      case (num, ns) if num.isFinite && ns.isZero => {
+        CoverageChecker.reached("floor", 1)
+        if (num.inNanoseconds < 0) {
+          CoverageChecker.reached("floor", 2)
+          ops.Bottom
+        } else {
+          CoverageChecker.reached("floor", 3)
+          ops.Top
+        }
+      }
+      case (num, denom) if num.isFinite && denom.isFinite => {
+        CoverageChecker.reached("floor", 4)
+        ops.fromNanoseconds((num.inNanoseconds / denom.inNanoseconds) * denom.inNanoseconds)
+      }
+      case (self, n) if n.isFinite => {
+        CoverageChecker.reached("floor", 5)
+        self
+      }
+      case (_, _) => {
+        CoverageChecker.reached("floor", 6)
+        ops.Undefined
+      }
+    }
   }
 
   def max(that: This): This =

--- a/util-core/src/test/scala/com/twitter/io/BufTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/BufTest.scala
@@ -12,6 +12,7 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 import org.scalatestplus.scalacheck.Checkers
 import scala.collection.mutable
 import java.nio.charset.Charset
+import com.twitter.util.CoverageChecker
 
 class BufTest
     extends FunSuite
@@ -1009,5 +1010,9 @@ class BufTest
       assert(constructor == concatLeft)
       assert(constructor == concatRight)
     }
+  }
+
+  test("CoverageChecker") {
+    println("[Coverage - equals] - " + CoverageChecker.map.getOrElse("equals", sys.error(s"unexpected key")).mkString("[",", ", "]"))
   }
 }

--- a/util-core/src/test/scala/com/twitter/util/ConfigTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/ConfigTest.scala
@@ -85,4 +85,10 @@ class ConfigTest extends WordSpec with Matchers {
       }
     }
   }
+    "CoverageChecker" in {
+      println("[Coverage - collect] - " + CoverageChecker.map.getOrElse(
+          "collect", sys.error(s"unexpected key")
+        ).mkString("[",", ", "]")
+      )
+    }
 }

--- a/util-core/src/test/scala/com/twitter/util/DurationTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/DurationTest.scala
@@ -19,6 +19,8 @@ package com.twitter.util
 import com.twitter.conversions.DurationOps._
 import java.util.concurrent.TimeUnit
 
+import com.twitter.util.CoverageChecker
+
 class DurationTest extends { val ops: Duration.type = Duration } with TimeLikeSpec[Duration] {
 
   "Duration" should {
@@ -289,6 +291,12 @@ class DurationTest extends { val ops: Duration.type = Duration } with TimeLikeSp
 
     "--Top == Top" in {
       assert(-(-Duration.Top) == Duration.Top)
+    }
+  }
+
+  "CoverageChecker" should {
+    "print map" in {
+      println(CoverageChecker.map.getOrElse("parse", sys.error(s"unexpected key")).mkString("[",", ", "]"))
     }
   }
 }

--- a/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
@@ -344,6 +344,7 @@ class PromiseTest extends FunSuite {
 
   test("CoverageChecker") {
     println("[Coverage - detach] - " + CoverageChecker.map.getOrElse("detach", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+    println("[Coverage - setInterruptHandler] - " + CoverageChecker.map.getOrElse("setInterruptHandler", sys.error(s"unexpected key")).mkString("[",", ", "]"))
     println("[Coverage - raise] - " + CoverageChecker.map.getOrElse("raise", sys.error(s"unexpected key")).mkString("[",", ", "]")) 
     println("[Coverage - continue] - " + CoverageChecker.map.getOrElse("continue", sys.error(s"unexpected key")).mkString("[",", ", "]"))
     println("[Coverage - link] - " + CoverageChecker.map.getOrElse("link", sys.error(s"unexpected key")).mkString("[",", ", "]"))

--- a/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
@@ -346,6 +346,7 @@ class PromiseTest extends FunSuite {
     println("[Coverage - continue] - " + CoverageChecker.map.getOrElse("continue", sys.error(s"unexpected key")).mkString("[",", ", "]"))
     println("[Coverage - link] - " + CoverageChecker.map.getOrElse("link", sys.error(s"unexpected key")).mkString("[",", ", "]"))
     println("[Coverage - detach] - " + CoverageChecker.map.getOrElse("detach", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+    println("[Coverage - updateIfEmpty] - " + CoverageChecker.map.getOrElse("updateIfEmpty", sys.error(s"unexpected key")).mkString("[",", ", "]"))
   }
 
 }

--- a/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
@@ -343,9 +343,10 @@ class PromiseTest extends FunSuite {
   }
 
   test("CoverageChecker") {
+    println("[Coverage - detach] - " + CoverageChecker.map.getOrElse("detach", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+    println("[Coverage - raise] - " + CoverageChecker.map.getOrElse("raise", sys.error(s"unexpected key")).mkString("[",", ", "]")) 
     println("[Coverage - continue] - " + CoverageChecker.map.getOrElse("continue", sys.error(s"unexpected key")).mkString("[",", ", "]"))
     println("[Coverage - link] - " + CoverageChecker.map.getOrElse("link", sys.error(s"unexpected key")).mkString("[",", ", "]"))
-    println("[Coverage - detach] - " + CoverageChecker.map.getOrElse("detach", sys.error(s"unexpected key")).mkString("[",", ", "]"))
     println("[Coverage - updateIfEmpty] - " + CoverageChecker.map.getOrElse("updateIfEmpty", sys.error(s"unexpected key")).mkString("[",", ", "]"))
   }
 

--- a/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
@@ -343,7 +343,9 @@ class PromiseTest extends FunSuite {
   }
 
   test("CoverageChecker") {
+    println("[Coverage - continue] - " + CoverageChecker.map.getOrElse("continue", sys.error(s"unexpected key")).mkString("[",", ", "]"))
     println("[Coverage - link] - " + CoverageChecker.map.getOrElse("link", sys.error(s"unexpected key")).mkString("[",", ", "]"))
     println("[Coverage - detach] - " + CoverageChecker.map.getOrElse("detach", sys.error(s"unexpected key")).mkString("[",", ", "]"))
   }
+
 }

--- a/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
@@ -2,6 +2,7 @@ package com.twitter.util
 
 import com.twitter.conversions.DurationOps._
 import org.scalatest.FunSuite
+import com.twitter.util.CoverageChecker
 
 class PromiseTest extends FunSuite {
 
@@ -339,5 +340,9 @@ class PromiseTest extends FunSuite {
 
     assert("main thread" == Await.result(p2, 3.seconds))
     assert("main thread" == Await.result(p, 3.seconds))
+  }
+
+  test("CoverageChecker") {
+    println("[Coverage] - " + CoverageChecker.map.getOrElse("detach", sys.error(s"unexpected key")).mkString("[",", ", "]"))
   }
 }

--- a/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/PromiseTest.scala
@@ -343,6 +343,7 @@ class PromiseTest extends FunSuite {
   }
 
   test("CoverageChecker") {
-    println("[Coverage] - " + CoverageChecker.map.getOrElse("detach", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+    println("[Coverage - link] - " + CoverageChecker.map.getOrElse("link", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+    println("[Coverage - detach] - " + CoverageChecker.map.getOrElse("detach", sys.error(s"unexpected key")).mkString("[",", ", "]"))
   }
 }

--- a/util-core/src/test/scala/com/twitter/util/TimeTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/TimeTest.scala
@@ -369,6 +369,14 @@ trait TimeLikeSpec[T <: TimeLike[T]] extends WordSpec with ScalaCheckDrivenPrope
       assert(fromMilliseconds(millis - 1) == Bottom)
     }
   }
+
+  // Print test coverage of Time.floor method
+  "CoverageChecker" in {
+    println("[Coverage - Floor] - " + CoverageChecker.map.getOrElse(
+        "floor", sys.error(s"unexpected key")
+      ).mkString("[",", ", "]")
+    )
+  }
 }
 
 class TimeFormatTest extends WordSpec {


### PR DESCRIPTION
This commit introduces the possibility to check the coverage of branches for ipToOptionInt in util/netUtil.scala via the AdHoc CoverageChecker. A print of the branches are added to the test suite as well. This resolves #42.

[Issue: #42]