### PR TITLE
[feat] Add test case for case exabyte in StorageUnit.factor (#45)

### DIFF
--- a/util-core/src/test/scala/com/twitter/util/StorageUnitTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/StorageUnitTest.scala
@@ -33,6 +33,7 @@ class StorageUnitTest extends FunSuite {
     assert(StorageUnit.parse("3.terabytes") == 3.terabytes)
     assert(StorageUnit.parse("9.petabytes") == 9.petabytes)
     assert(StorageUnit.parse("-3.megabytes") == -3.megabytes)
+    assert(StorageUnit.parse("3.exabytes") == 3.petabytes * 1024)
   }
 
   test("StorageUnit: should reject soulless robots") {


### PR DESCRIPTION
The method StorageUnit.factor is supposed to match the strings to the corresponding long numbers. However, this behavior did not have tests for processing strings containing "exabyte". This commit address this problem.

[Issue: #45]