### PR TITLE
[feat] Add test for dot3==-1 in iptoOptionInt

### DIFF
--- a/util-core/src/test/scala/com/twitter/util/NetUtilTest.scala
+++ b/util-core/src/test/scala/com/twitter/util/NetUtilTest.scala
@@ -143,5 +143,9 @@ class NetUtilTest extends WordSpec {
         NetUtil.isIpInBlocks("0.0.0.256", blocks)
       }
     }
+
+    "ipToOptionInt should not accept an IP string without a third period" in {
+      assert(NetUtil.ipToOptionInt("127.0.0") == None)
+    }
   }
 }


### PR DESCRIPTION
This commit adds a test for the case when an invalid invalid IP-address is used (less than 3 dots, ex `127.0.0`). Resolves #49 

[Issue: #49]