### PR TITLE
[feat] Add CoverageChecker to resizeIfNeeded

### DIFF
--- a/util-core/src/main/scala/com/twitter/io/BufByteWriterImpl.scala
+++ b/util-core/src/main/scala/com/twitter/io/BufByteWriterImpl.scala
@@ -275,7 +275,7 @@ private final class DynamicBufByteWriter(arr: Array[Byte]) extends AbstractBufBy
   // the size is scaled back to `requiredSize`.
   private[this] def resizeIfNeeded(requiredRemainingBytes: Int): Unit = {
     val funcName = "resizeIfNeeded"
-    CoverageChecker.initialize(funcName, 5)
+    CoverageChecker.initialize(funcName, 6)
     if (requiredRemainingBytes > underlying.remaining) {
       CoverageChecker.reached(funcName, 0)
       var size: Int = underlying.array.length
@@ -306,6 +306,8 @@ private final class DynamicBufByteWriter(arr: Array[Byte]) extends AbstractBufBy
       if (size < 0 || requiredSize > MaxBufferSize) {
         CoverageChecker.reached(funcName, 3)
         size = requiredSize
+      } else {
+        CoverageChecker.reached(funcName, 4)
       }
 
 
@@ -314,7 +316,7 @@ private final class DynamicBufByteWriter(arr: Array[Byte]) extends AbstractBufBy
       System.arraycopy(underlying.array, 0, newArr, 0, written)
       underlying = new FixedBufByteWriter(newArr, written)
     } else {
-      CoverageChecker.reached(funcName, 4)
+      CoverageChecker.reached(funcName, 5)
     }
   }
 

--- a/util-core/src/main/scala/com/twitter/io/BufByteWriterImpl.scala
+++ b/util-core/src/main/scala/com/twitter/io/BufByteWriterImpl.scala
@@ -3,6 +3,7 @@ package com.twitter.io
 import com.twitter.io.ByteWriter.OverflowException
 import java.nio.{ByteBuffer, CharBuffer}
 import java.nio.charset.{Charset, CoderResult, CodingErrorAction}
+import com.twitter.util.CoverageChecker
 
 /**
  * Abstract implementation of the `BufByteWriter` that is specialized to write to an
@@ -273,8 +274,10 @@ private final class DynamicBufByteWriter(arr: Array[Byte]) extends AbstractBufBy
   // the buffer size to overflow, but the contents will still fit in `MaxBufferSize`,
   // the size is scaled back to `requiredSize`.
   private[this] def resizeIfNeeded(requiredRemainingBytes: Int): Unit = {
+    val funcName = "resizeIfNeeded"
+    CoverageChecker.initialize(funcName, 5)
     if (requiredRemainingBytes > underlying.remaining) {
-
+      CoverageChecker.reached(funcName, 0)
       var size: Int = underlying.array.length
 
       val written = size - underlying.remaining
@@ -282,27 +285,36 @@ private final class DynamicBufByteWriter(arr: Array[Byte]) extends AbstractBufBy
       val requiredSize: Int = written + requiredRemainingBytes
 
       // Check to make sure we won't exceed max buffer size
-      if (requiredSize < 0 || requiredSize > MaxBufferSize)
+      if (requiredSize < 0 || requiredSize > MaxBufferSize) {
+        CoverageChecker.reached(funcName, 1)
         throw new OverflowException(
           s"maximum dynamic buffer size is $MaxBufferSize." +
             s" Insufficient space to write $requiredRemainingBytes bytes"
         )
+      }
+
 
       // Increase size of the buffer by 50% until it can contain `requiredBytes`
       while (requiredSize > size && size > 0) {
+        CoverageChecker.reached(funcName, 2)
         size = (size * 3) / 2 + 1
       }
 
       // If we've overflowed by increasing the size, scale back to `requiredSize`.
       // We know that we can still fit the current + new bytes, because of
       // the requiredSize check above.
-      if (size < 0 || requiredSize > MaxBufferSize)
+      if (size < 0 || requiredSize > MaxBufferSize) {
+        CoverageChecker.reached(funcName, 3)
         size = requiredSize
+      }
+
 
       // Create a new underlying buffer
       val newArr = new Array[Byte](size)
       System.arraycopy(underlying.array, 0, newArr, 0, written)
       underlying = new FixedBufByteWriter(newArr, written)
+    } else {
+      CoverageChecker.reached(funcName, 4)
     }
   }
 

--- a/util-core/src/test/scala/com/twitter/io/BufByteWriterTest.scala
+++ b/util-core/src/test/scala/com/twitter/io/BufByteWriterTest.scala
@@ -4,6 +4,7 @@ import java.lang.{Double => JDouble, Float => JFloat}
 import java.nio.charset.StandardCharsets
 import org.scalatest.FunSuite
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import com.twitter.util.CoverageChecker
 
 final class BufByteWriterTest extends FunSuite with ScalaCheckDrivenPropertyChecks {
   import ByteWriter.OverflowException
@@ -296,6 +297,10 @@ final class BufByteWriterTest extends FunSuite with ScalaCheckDrivenPropertyChec
       .owned()
     assert(buf == bytes.concat(bytes).concat(bytes))
   })
+
+   test("CoverageChecker") {
+    println("[Coverage - resizeIfNeeded] - " + CoverageChecker.map.getOrElse("resizeIfNeeded", sys.error(s"unexpected key")).mkString("[",", ", "]"))
+  }
 
   // Requires additional heap space to run.
   // Pass JVM option '-Xmx8g'.


### PR DESCRIPTION
This PR adds coverage checking for the function 'resizeIfNeeded' in io/BufByteWriterImpl.scala. Resolves #56 

[Issue: #56]